### PR TITLE
Fixes #23445

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ sdist: clean docs
 sdist_upload: clean docs
 	$(PYTHON) setup.py sdist upload 2>&1 |tee upload.log
 
-rpmcommon: docs sdist
+rpmcommon: sdist
 	@mkdir -p rpm-build
 	@cp dist/*.gz rpm-build/
 	@sed -e 's#^Version:.*#Version: $(VERSION)#' -e 's#^Release:.*#Release: $(RPMRELEASE)%{?dist}#' $(RPMSPEC) >rpm-build/$(NAME).spec


### PR DESCRIPTION
##### SUMMARY

Fixes #23445

make rpm fail with error:

cp: cannot stat 'docs/man/man1/*.1': No such file or directory
error: Bad exit status from /var/tmp/rpm-tmp.CaBVhB (%install)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Makefile
make rpm

##### ANSIBLE VERSION
```
ansible-2.4.0-100.git201704091600.83a6d90.devel
```


##### ADDITIONAL INFORMATION

docs set twice in make sequence
may be optimizer launch first `make docs`, and second `make clean`
